### PR TITLE
Automatic

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,39 +1,47 @@
 $(function(){
 
+  
+
+  
+
   function buildHTML(message){
 
     if (message.image) {
       var html = 
-      `<div class="main__chat-main__message-list-box-minibox">
-        <div class="main__chat-main__message-list-box-minibox-name">
-        ${ message.user_name }
+      `<div class="main__chat-main__message-list-box-box1" data-message-id="${message.id}">
+        <div class="main__chat-main__message-list-box-box1-minibox">
+          <div class="main__chat-main__message-list-box-box1-minibox-name">
+            ${ message.user_name }
+          </div>
+          <div class="main__chat-main__message-list-box-box1-minibox-date">
+            ${ message.created_at}
+          </div>
         </div>
-        <div class="main__chat-main__message-list-box-minibox-date">
-        ${ message.created_at}
-        </div>
-      </div>
-        <div class="main__chat-main__message-list-box">
-          <p class="main__chat-main__message-list-box">
-          ${ message.content }
+        <div class="main__chat-main__message-list-box-box1-content">
+          <p class="main__chat-main__message-list-box-box1-content-p">
+            ${ message.content }
           </p>
           <img class="lower-message__image" src="${message.image}" alt="Hero img">
-        </div>`
+        </div>
+      </div>`
        
     } else {
       var html = 
-      `<div class="main__chat-main__message-list-box-minibox">
-        <div class="main__chat-main__message-list-box-minibox-name">
-        ${ message.user_name }
+      `<div class="main__chat-main__message-list-box-box1" data-message-id="${message.id}">
+        <div class="main__chat-main__message-list-box-box1-minibox">
+          <div class="main__chat-main__message-list-box-box1-minibox-name">
+            ${ message.user_name }
+          </div>
+          <div class="main__chat-main__message-list-box-box1-minibox-date">
+            ${ message.created_at}
+          </div>
         </div>
-        <div class="main__chat-main__message-list-box-minibox-date">
-        ${ message.created_at}
-        </div>
-      </div>
-        <div class="main__chat-main__message-list-box">
-          <p class="main__chat-main__message-list-box">
-          ${ message.content }
+        <div class="main__chat-main__message-list-box-box1-content">
+          <p class="main__chat-main__message-list-box-box1-content-p">
+            ${ message.content }
           </p>
-        </div>`
+        </div>
+      </div>`
       
     }
     return html
@@ -54,9 +62,10 @@ $(function(){
       contentType: false
     })
     .done(function(data){
+      
       var html = buildHTML(data);
       
-      $('.main__chat-main__message-list').append(html);
+      $('.main__chat-main__message-list-box').append(html);
       $('#new_message')[0].reset();
       $('.form__submit').prop('disabled', false);
       $('.main__chat-main__message-list').animate({ scrollTop: $('.main__chat-main__message-list')[0].scrollHeight});
@@ -67,4 +76,39 @@ $(function(){
       alert("メッセージ送信に失敗しました");
     })
   })
+
+  var reloadMessages = function() {
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){
+      
+      last_message_id = $('.main__chat-main__message-list-box-box1').last().data("message-id");
+      
+      $.ajax({
+        //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+        url: "api/messages",
+        //ルーティングで設定した通りhttpメソッドをgetに指定
+        type: 'get',
+        dataType: 'json',
+        //dataオプションでリクエストに値を含める
+        data: {id: last_message_id}
+      })
+      .done(function(messages) {
+        
+          if(messages.length > 0){
+            var insertHTML = '';
+        //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        //メッセージが入ったHTMLに、入れ物ごと追加
+        $('.main__chat-main__message-list-box').append(insertHTML);
+        $('.main__chat-main__message-list').animate({scrollTop: $('.main__chat-main__message-list')[0].scrollHeight}, 'fast');
+        }
+      })
+      .fail(function() {
+        
+      });
+    }
+  };
+  setInterval(reloadMessages, 7000);
 });
+

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -126,15 +126,16 @@ padding-left: 5px;
         background-color: #fafafa;
         overflow: scroll;
         &-box {
+          &-box1{
           padding-bottom: 40px;
-          &-minibox {
-            display: flex;
-            margin-bottom: 10px;
-            &-name {
-              color: #434a54;
-              font-size: 16px;
-              font-weight: bold;
-            }
+            &-minibox {
+              display: flex;
+              margin-bottom: 10px;
+              &-name {
+                color: #434a54;
+                font-size: 16px;
+                font-weight: bold;
+              }
             &-date {
               color: #999999;
               font-size: 12px;
@@ -146,6 +147,7 @@ padding-left: 5px;
             font-size: 14px;
             margin-bottom: 10px;
           }
+        }
         }
       }
 

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/create.json.jbuilder
+++ b/app/views/api/messages/create.json.jbuilder
@@ -1,0 +1,6 @@
+json.content    @message.content
+json.image      @message.image.url
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.user_name @message.user.name
+#idもデータとして渡す
+json.id @message.id

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,11 +1,11 @@
-
-.main__chat-main__message-list-box-minibox
-  .main__chat-main__message-list-box-minibox-name
-    = message.user.name
-  .main__chat-main__message-list-box-minibox-date
-    = message.created_at.strftime("%Y/%m/%d %H:%M")
-.main__chat-main__message-list-box
-  - if message.content.present?
-    %p.main__chat-main__message-list-box
-      = message.content
-  = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
+.main__chat-main__message-list-box-box1{"data-message-id": "#{message.id}"}
+  .main__chat-main__message-list-box-box1-minibox
+    .main__chat-main__message-list-box-box1-minibox-name
+      = message.user.name
+    .main__chat-main__message-list-box-box1-minibox-date
+      = message.created_at.strftime("%Y/%m/%d %H:%M")
+  .main__chat-main__message-list-box-box1-content
+    - if message.content.present?
+      %p.main__chat-main__message-list-box-box1-content-p
+        = message.content
+    = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,4 +2,4 @@ json.content  @message.content
 json.user_name @message.user.name
 json.created_at   @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.image  @message.image.url
-
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#why
自動更新機能の実装
同じブラウザを見ている人の画面に更新されたメッセージが表示できるようにするため。

＃what
①表示されているメッセージのidが確認できるように設定
②新規投稿を取得できるように設定
③投稿内容をレスポンスできるように設定
④取得した投稿データを表示できるように設定
⑤自動更新が必要ない画面では行わないように設定

自動更新機能実装の確認動画のURLです。
https://gyazo.com/d9719fa11ce0358883ec985e51b5c762
